### PR TITLE
RJ - Added the Index page for Help Requests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -55,7 +55,11 @@ function App() {
       )}
       {hasRole(currentUser, "ROLE_USER") && (
         <>
-          <Route exact path="/helprequests" element={<HelpRequestIndexPage />} />
+          <Route
+            exact
+            path="/helprequests"
+            element={<HelpRequestIndexPage />}
+          />
         </>
       )}
       {hasRole(currentUser, "ROLE_ADMIN") && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -55,19 +55,19 @@ function App() {
       )}
       {hasRole(currentUser, "ROLE_USER") && (
         <>
-          <Route exact path="/helprequest" element={<HelpRequestIndexPage />} />
+          <Route exact path="/helprequests" element={<HelpRequestIndexPage />} />
         </>
       )}
       {hasRole(currentUser, "ROLE_ADMIN") && (
         <>
           <Route
             exact
-            path="/helprequest/edit/:id"
+            path="/helprequests/edit/:id"
             element={<HelpRequestEditPage />}
           />
           <Route
             exact
-            path="/helprequest/create"
+            path="/helprequests/create"
             element={<HelpRequestCreatePage />}
           />
         </>

--- a/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
+++ b/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
@@ -17,7 +17,7 @@ export default function HelpRequestTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/help-requests/edit/${cell.row.original.id}`);
+    navigate(`/helprequests/edit/${cell.row.original.id}`);
   };
 
   // Stryker disable all : hard to test for query caching
@@ -25,7 +25,7 @@ export default function HelpRequestTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/help-requests/all"],
+    ["/api/helprequests/all"],
   );
   // Stryker restore all
 

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -71,7 +71,7 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/helprequest">
+                  <Nav.Link as={Link} to="/helprequests">
                     Help Requests
                   </Nav.Link>
                 </>

--- a/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
@@ -38,7 +38,7 @@ export default function HelpRequestCreatePage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/helprequest" />;
+    return <Navigate to="/helprequests" />;
   }
 
   return (

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -40,7 +40,10 @@ export default function HelpRequestIndexPage() {
       <div className="pt-2">
         {createButton()}
         <h1>Help Requests</h1>
-        <HelpRequestTable helpRequests={helpRequests} currentUser={currentUser} />
+        <HelpRequestTable
+          helpRequests={helpRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: helpRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequests/all"],
+    { method: "GET", url: "/api/helprequests/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequests/create"
+          style={{ float: "right" }}
+        >
+          Create Help Request
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequest/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequest/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Help Requests</h1>
+        <HelpRequestTable helpRequests={helpRequests} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell) {
   return {
-    url: "/api/help-requests",
+    url: "/api/helprequests",
     method: "DELETE",
     params: {
       id: cell.row.original.id,

--- a/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.jsx
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.jsx
@@ -35,7 +35,7 @@ ThreeItemsAdminUser.args = {
 
 ThreeItemsAdminUser.parameters = {
   msw: [
-    http.delete("/api/help-requests", () => {
+    http.delete("/api/helprequests", () => {
       return HttpResponse.json(
         { message: "Help request deleted successfully" },
         { status: 200 },

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeRequests);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeRequests);
+    }),
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json(
+        { message: "Help request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -199,7 +199,7 @@ describe("HelpRequestTable tests", () => {
 
     // assert - check that the navigate function was called with the expected path
     await waitFor(() =>
-      expect(mockedNavigate).toHaveBeenCalledWith("/help-requests/edit/1"),
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequests/edit/1"),
     );
   });
 
@@ -208,8 +208,7 @@ describe("HelpRequestTable tests", () => {
     const currentUser = currentUserFixtures.adminUser;
 
     const axiosMock = new AxiosMockAdapter(axios);
-    axiosMock
-      .onDelete("/api/help-requests")
+    axiosMock.onDelete("/api/helprequests")
       .reply(200, { message: "Help request deleted" });
 
     // act - render the component

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -208,7 +208,8 @@ describe("HelpRequestTable tests", () => {
     const currentUser = currentUserFixtures.adminUser;
 
     const axiosMock = new AxiosMockAdapter(axios);
-    axiosMock.onDelete("/api/helprequests")
+    axiosMock
+      .onDelete("/api/helprequests")
       .reply(200, { message: "Help request deleted" });
 
     // act - render the component

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
@@ -60,7 +60,7 @@ describe("HelpRequestCreatePage tests", () => {
     });
   });
 
-  test("on submit, makes request to backend, and redirects to /helprequest", async () => {
+  test("on submit, makes request to backend, and redirects to /helprequests", async () => {
     const queryClient = new QueryClient();
     const helpRequest = {
       id: 3,
@@ -128,6 +128,6 @@ describe("HelpRequestCreatePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "New help request Created - id: 3 requesterEmail: test@example.com teamId: 1 tableOrBreakoutRoom: Table 1 requestTime: 2025-10-14T12:00:00 explanation: Help needed solved: false",
     );
-    expect(mockNavigate).toBeCalledWith({ to: "/helprequest" });
+    expect(mockNavigate).toBeCalledWith({ to: "/helprequests" });
   });
 });

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
@@ -1,16 +1,28 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "HelpRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -36,12 +48,10 @@ describe("HelpRequestIndexPage tests", () => {
 
   const queryClient = new QueryClient();
 
-  test("Renders expected content for ordinary user", async () => {
-    // arrange
-    setupUserOnly();
-    axiosMock.onGet("/api/helprequests/all").reply(200, helpRequestFixtures.threeRequests);
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequests/all").reply(200, []);
 
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -50,23 +60,20 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
     await waitFor(() => {
-      expect(screen.getByText("Help Requests")).toBeInTheDocument();
+      expect(screen.getByText(/Create Help Request/)).toBeInTheDocument();
     });
-
-    expect(screen.getByText("Help Requests")).toBeInTheDocument();
-
-    // Create button should not be visible for ordinary users
-    expect(screen.queryByText("Create Help Request")).not.toBeInTheDocument();
+    const button = screen.getByText(/Create Help Request/);
+    expect(button).toHaveAttribute("href", "/helprequests/create");
+    expect(button).toHaveAttribute("style", "float: right;");
   });
 
-  test("Renders expected content for admin user", async () => {
-    // arrange
-    setupAdminUser();
-    axiosMock.onGet("/api/helprequests/all").reply(200, helpRequestFixtures.threeRequests);
+  test("renders three help requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeRequests);
 
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -75,14 +82,105 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
     await waitFor(() => {
-      expect(screen.getByText("Help Requests")).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createHelpRequestButton = screen.queryByText("Create Help Request");
+    expect(createHelpRequestButton).not.toBeInTheDocument();
+
+    const email1 = screen.getByText("test1@example.com");
+    expect(email1).toBeInTheDocument();
+
+    const explanation1 = screen.getByText("Test explanation 1");
+    expect(explanation1).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+    expect(
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/helprequests/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
-    expect(screen.getByText("Help Requests")).toBeInTheDocument();
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequests/all",
+    );
+    restoreConsole();
+  });
 
-    // Create button should be visible for admin users
-    expect(screen.getByText("Create Help Request")).toBeInTheDocument();
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeRequests);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, "Help request with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("Help request with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequests");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
@@ -22,14 +23,25 @@ describe("HelpRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
+  const queryClient = new QueryClient();
+
+  test("Renders expected content for ordinary user", async () => {
+    // arrange
     setupUserOnly();
+    axiosMock.onGet("/api/helprequests/all").reply(200, helpRequestFixtures.threeRequests);
 
     // act
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,13 +50,39 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    // assert
+    await waitFor(() => {
+      expect(screen.getByText("Help Requests")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Help Requests")).toBeInTheDocument();
+
+    // Create button should not be visible for ordinary users
+    expect(screen.queryByText("Create Help Request")).not.toBeInTheDocument();
+  });
+
+  test("Renders expected content for admin user", async () => {
+    // arrange
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequests/all").reply(200, helpRequestFixtures.threeRequests);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
     // assert
-    expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Help Requests")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Help Requests")).toBeInTheDocument();
+
+    // Create button should be visible for admin users
+    expect(screen.getByText("Create Help Request")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/utils/helpRequestUtils.test.js
+++ b/frontend/src/tests/utils/helpRequestUtils.test.js
@@ -41,7 +41,7 @@ describe("helpRequestUtils", () => {
 
       // assert
       expect(result).toEqual({
-        url: "/api/help-requests",
+        url: "/api/helprequests",
         method: "DELETE",
         params: { id: 17 },
       });


### PR DESCRIPTION
Closes #44 
This includes the updated index page for Help Requests to display the current data it holds, tests for it, and the updated storybook.
To test visit: https://team02-rohiljainucsb-dev.dokku-16.cs.ucsb.edu/
By visiting the index page for Help Requests, create and options should work correctly.

Screenshot:
<img width="935" height="309" alt="image" src="https://github.com/user-attachments/assets/184c3cb0-f325-46ba-b2a6-9c7dd2af4e80" />
Storybook: https://69f27b4c5302ca70c625d656-favnxarszb.chromatic.com/?path=/story/pages-helprequests-helprequestindexpage--three-items-ordinary-user